### PR TITLE
Enforce Dynamic Rendering in GraphQL client

### DIFF
--- a/app/animals/[animalId]/page.tsx
+++ b/app/animals/[animalId]/page.tsx
@@ -2,8 +2,6 @@ import { gql } from '@apollo/client';
 import Image from 'next/image';
 import { getClient } from '../../../util/apolloClient';
 
-export const dynamic = 'force-dynamic';
-
 type Props = {
   params: { animalId: string };
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,8 +43,6 @@ export default async function Home() {
     `,
   });
 
-  console.log('Data: ', data);
-
   return (
     <main
       style={{

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "migrate": "dotenv -- ley --require tsm"
   },
   "dependencies": {
-    "@apollo/client": "3.8.0-alpha.15",
-    "@apollo/experimental-nextjs-app-support": "^0.1.0",
+    "@apollo/client": "3.8.0-beta.5",
+    "@apollo/experimental-nextjs-app-support": "^0.3.2",
     "@apollo/server": "^4.7.1",
     "@as-integrations/next": "^2.0.0",
     "@graphql-tools/schema": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -6,11 +6,11 @@ settings:
 
 dependencies:
   '@apollo/client':
-    specifier: 3.8.0-alpha.15
-    version: 3.8.0-alpha.15(graphql@16.6.0)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 3.8.0-beta.5
+    version: 3.8.0-beta.5(graphql@16.6.0)(react-dom@18.2.0)(react@18.2.0)
   '@apollo/experimental-nextjs-app-support':
-    specifier: ^0.1.0
-    version: 0.1.0(@apollo/client@3.8.0-alpha.15)(next@13.4.4)(react@18.2.0)
+    specifier: ^0.3.2
+    version: 0.3.2(@apollo/client@3.8.0-beta.5)(next@13.4.4)(react@18.2.0)
   '@apollo/server':
     specifier: ^4.7.1
     version: 4.7.1(encoding@0.1.13)(graphql@16.6.0)
@@ -103,8 +103,8 @@ packages:
       graphql: 16.6.0
     dev: false
 
-  /@apollo/client@3.8.0-alpha.15(graphql@16.6.0)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-725uCJ7m/+39nHj7tUb3NMr3I6Fyth3GFtMjSVx5w4FngZiLF4xszXzH8sGZxfAlKagXMVKK0EDncAoFXoY16A==}
+  /@apollo/client@3.8.0-beta.5(graphql@16.6.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-8ULBWINWMBKe/yMingMQfhdRpOXTEauWC/vMXzEJ5DIcAudclPfmFZCjJsSyhU4Vg5lVzU5AOKi5g6v0AVkeCg==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
       graphql-ws: ^5.5.5
@@ -139,14 +139,14 @@ packages:
       zen-observable-ts: 1.2.5
     dev: false
 
-  /@apollo/experimental-nextjs-app-support@0.1.0(@apollo/client@3.8.0-alpha.15)(next@13.4.4)(react@18.2.0):
-    resolution: {integrity: sha512-RBDzsZLHYBnbPkh3NVlIZUxynO2ASbCpO7JEmcZRZIzMbCMpH6wXmPrenD6hxOEgLxWzxS2F3q5VlTGXtmb3ww==}
+  /@apollo/experimental-nextjs-app-support@0.3.2(@apollo/client@3.8.0-beta.5)(next@13.4.4)(react@18.2.0):
+    resolution: {integrity: sha512-h219jTHVl7vR6RtUv9GJrv8+EbtQpUUvcNrM4aPWqOMvq1vN95T33Z96la7iWEWruwBvcWQD7UreAOdbd432Gw==}
     peerDependencies:
-      '@apollo/client': '>= 3.8.0-alpha.13'
+      '@apollo/client': '>=3.8.0-beta.4'
       next: ^13.4.1
       react: ^18
     dependencies:
-      '@apollo/client': 3.8.0-alpha.15(graphql@16.6.0)(react-dom@18.2.0)(react@18.2.0)
+      '@apollo/client': 3.8.0-beta.5(graphql@16.6.0)(react-dom@18.2.0)(react@18.2.0)
       next: 13.4.4(@babel/core@7.22.1)(react-dom@18.2.0)(react@18.2.0)(sass@1.62.1)
       react: 18.2.0
       superjson: 1.12.3

--- a/util/apolloClient.ts
+++ b/util/apolloClient.ts
@@ -27,6 +27,7 @@ export const { getClient } = registerApolloClient(() => {
     localLink,
   );
 
+  headers();
   return new ApolloClient({
     cache: new InMemoryCache(),
     link,

--- a/util/apolloClient.ts
+++ b/util/apolloClient.ts
@@ -1,5 +1,6 @@
 import { ApolloClient, HttpLink, InMemoryCache, split } from '@apollo/client';
 import { registerApolloClient } from '@apollo/experimental-nextjs-app-support/rsc';
+import { headers } from 'next/headers';
 
 export const { getClient } = registerApolloClient(() => {
   // GitHub Link

--- a/util/apolloClient.ts
+++ b/util/apolloClient.ts
@@ -27,6 +27,7 @@ export const { getClient } = registerApolloClient(() => {
     localLink,
   );
 
+  // Call `headers()` from next/headers to trigger Next.js Dynamic Rendering.
   headers();
   return new ApolloClient({
     cache: new InMemoryCache(),


### PR DESCRIPTION
Closes https://github.com/upleveled/graphql-example-spring-2023-austria-vienna/issues/2

Add  Next.js `headers()` to run when `registerApolloClient()` is called

The `headers()` is called on every page navigation. 


https://github.com/upleveled/graphql-example-spring-2023-austria-vienna/assets/74430629/536cdbb1-b465-4f49-b16d-403bb8302dbb


